### PR TITLE
Respect deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pip install Flask-Tus
 
 ```python
 from flask import Flask, render_template, send_from_directory
-from flask.ext.tus import tus_manager
+from flask_tus import tus_manager
 import os
 
 app = Flask(__name__)


### PR DESCRIPTION
```
/Users/seth/src/americanredcross/imagery-api/venv/lib/python2.7/site-packages/flask/exthook.py:71: ExtDeprecationWarning: Importing flask.ext.tus is deprecated, use flask_tus instead.
  .format(x=modname), ExtDeprecationWarning
```
